### PR TITLE
Fixed link typo

### DIFF
--- a/computer-organisation.md
+++ b/computer-organisation.md
@@ -1,7 +1,7 @@
 
 
 
-[register names:](https:#docs.microsoft.com/en-us/windows-hardware/drivers/debugger/x64-architecture)
+[register names:](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/x64-architecture)
 
 |64-bit register | Lower 32 bits | Lower 16 bits | Lower 8 bits		|
 | -------------- | ------------- | ------------- | ---------------- |


### PR DESCRIPTION
Fixed a small typo will probably reformat it a bit with an index and such to make it clearer later